### PR TITLE
Add script to replace Gmail's URL of images with their original URL

### DIFF
--- a/scripts/replace-gmail-url-of-images-with-their-original-url.js
+++ b/scripts/replace-gmail-url-of-images-with-their-original-url.js
@@ -1,0 +1,81 @@
+// ==UserScript==
+// @name         Replace Gmail's URL of images with their original URL
+// @namespace    http://tampermonkey.net/
+// @updateURL    https://raw.githubusercontent.com/Spendesk/tampermonkey-scripts/master/scripts/replace-gmail-url-of-images-with-their-original-url.js
+// @downloadURL  https://raw.githubusercontent.com/Spendesk/tampermonkey-scripts/master/scripts/replace-gmail-url-of-images-with-their-original-url.js
+// @version      0.1
+// @description  Gmail caches images in email on their own servers and serves them via their CDN. This script rewrites the images URLs so they point to the original URL instead of the Gmail's cached copy.
+// @author       Spendesk
+// @match        mail.google.com/*
+// @grant        none
+// @icon         https://www.spendesk.com/favicon-32x32.png
+// ==/UserScript==
+
+(function() {
+  'use strict';
+  const REGEX = /https:\/\/.*\.googleusercontent\.com\/.*#(https?:\/\/.*)/i;
+
+  const rewriteImageUrls = (container) => {
+      // Rewrite img source on <img> tags
+      Array.from(
+          container.querySelectorAll('img')
+      ).forEach(img => {
+          const match = img.src.match(REGEX);
+
+          if (!match) {
+              return;
+          }
+
+          const [, originalURL] = match;
+
+          img.src = originalURL;
+      });
+
+      // Rewrite img source on CSS backgrounds
+      Array.from(
+          container.querySelectorAll('[style]')
+      ).forEach(element => {
+          if (!element.style.backgroundImage && !element.style.background) {
+              return;
+          }
+
+          let match;
+          let fromBackground = false;
+          let fromBackgroundImage = false;
+
+          if (element.style.backgroundImage) {
+              match = element.style.backgroundImage.match(REGEX);
+              fromBackgroundImage = true;
+          }
+
+          if (!match) {
+              match = element.style.background.match(REGEX);
+              fromBackground = true;
+          }
+
+          if (!match) {
+              return;
+          }
+
+          const [input, originalURL] = match;
+
+          if (fromBackgroundImage) {
+              element.style.backgroundImage = element.style.backgroundImage
+                  .replace(input, originalURL);
+          }
+
+          if (fromBackground) {
+              element.style.background = element.style.background
+                  .replace(input, originalURL);
+          }
+      });
+  };
+
+  setInterval(() => {
+      const emailContainer = document.querySelector('.ii.gt.adO');
+
+      if (emailContainer) {
+          rewriteImageUrls(emailContainer);
+      }
+  }, 1000);
+})();


### PR DESCRIPTION
I used to have it as a Chrome DevTools' snippet and run it manually, so here I made a loop to execute it every 1 second, which isn't ideal but it will be fine I guess.
The correct way would be to inject a button in the UI to trigger it. If the user needs to disable it, it can disable the TamperMonkey script itself.

You might want to try it first because I'm not sure that Gmail's HTML classes and IDs are stable.