### PR TITLE
Fix - Filter - Re allow click on collection

### DIFF
--- a/scripts/filter-on-forest.js
+++ b/scripts/filter-on-forest.js
@@ -33,7 +33,7 @@ const filter = () => {
 };
 
 const addSidebarSearch = (sidebar) => {
-  const button = `
+  const htmlSearchbar = `
 <div class='c-beta-header__search-bar c-beta-search-bar ember-view' style='margin-top: 5px; margin-bottom: 5px;'>
 <i class='material-icons c-beta-search-bar__icon' role='button' data-ember-action=''>search</i>
 <form class='c-beta-search-bar__form' data-ember-action=''>
@@ -41,11 +41,13 @@ const addSidebarSearch = (sidebar) => {
 </form>
 </div>`;
 
-  sidebar.innerHTML = button + sidebar.innerHTML;
-  const domButton = document.querySelector('#filterSearchBar');
-  domButton.addEventListener('keyup', filter);
+  const domSearchBarDiv = document.createElement('div');
+  domSearchBarDiv.innerHTML = htmlSearchbar;
+  sidebar.prepend(domSearchBarDiv);
+  const domSearchBar = document.querySelector('#filterSearchBar');
+  domSearchBar.addEventListener('keyup', filter);
 
-  domButton.focus();
+  domSearchBar.focus();
 };
 
 const main = async () => {

--- a/scripts/filter-on-forest.js
+++ b/scripts/filter-on-forest.js
@@ -3,7 +3,7 @@
 // @namespace    https://spendesk.com
 // @updateURL    https://raw.githubusercontent.com/Spendesk/tampermonkey-scripts/master/scripts/filter-on-forest.js
 // @downloadURL  https://raw.githubusercontent.com/Spendesk/tampermonkey-scripts/master/scripts/filter-on-forest.js
-// @version      0.1
+// @version      0.2
 // @description  Add a filter on forest for the sidebar
 // @author       Spendesk
 // @match        *://app.forestadmin.com/*

--- a/scripts/filter-on-forest.js
+++ b/scripts/filter-on-forest.js
@@ -17,41 +17,42 @@ const wait = (timeout) =>
   });
 
 const filter = () => {
-  const filterSearchBar = document.querySelector('#filterSearchBar');
+  const filterSearchBar = document.querySelector("#filterSearchBar");
   const searchTerm = filterSearchBar.value.toLowerCase();
 
-  const sideMenuItems = document.querySelectorAll('.c-side-menu-item');
+  const sideMenuItems = document.querySelectorAll(".c-side-menu-item");
   for (const sideMenuItem of sideMenuItems) {
     const sideMenuItemName = sideMenuItem.innerText.toLowerCase();
     const sideMenuDiv = sideMenuItem.parentElement;
     if (sideMenuItemName.includes(searchTerm)) {
-      sideMenuDiv.style.display = 'block';
+      sideMenuDiv.style.display = "block";
     } else {
-      sideMenuDiv.style.display = 'none';
+      sideMenuDiv.style.display = "none";
     }
   }
 };
 
 const addSidebarSearch = (sidebar) => {
   const htmlSearchbar = `
-<div class='c-beta-header__search-bar c-beta-search-bar ember-view' style='margin-top: 5px; margin-bottom: 5px;'>
-<i class='material-icons c-beta-search-bar__icon' role='button' data-ember-action=''>search</i>
-<form class='c-beta-search-bar__form' data-ember-action=''>
-<input autocomplete='off' placeholder='Filter collection' class='c-beta-search-bar__input ember-text-field ember-view' type='text' id='filterSearchBar'>
-</form>
-</div>`;
+  <div class="c-beta-header__search-bar c-beta-search-bar" style="margin-top: 5px; margin-bottom: 5px;">
+  <i class="material-icons c-beta-search-bar__icon" role="button" data-ember-action="">search</i>
+    <form class="c-beta-search-bar__form" data-ember-action="">
+      <input autocomplete="off" placeholder="Filter collection" class="c-beta-search-bar__input ember-text-field ember-view" type="text" id="filterSearchBar">
+    </form>
+  </div>
+`;
 
-  const domSearchBarDiv = document.createElement('div');
+  const domSearchBarDiv = document.createElement("div");
   domSearchBarDiv.innerHTML = htmlSearchbar;
   sidebar.prepend(domSearchBarDiv);
-  const domSearchBar = document.querySelector('#filterSearchBar');
-  domSearchBar.addEventListener('keyup', filter);
+  const domSearchBar = document.querySelector("#filterSearchBar");
+  domSearchBar.addEventListener("keyup", filter);
 
   domSearchBar.focus();
 };
 
 const main = async () => {
-  const sidebar = document.querySelector('.l-sidebar');
+  const sidebar = document.querySelector(".l-sidebar");
   if (sidebar) {
     return addSidebarSearch(sidebar);
   }
@@ -59,7 +60,7 @@ const main = async () => {
   main();
 };
 
-(async function() {
-  'use strict';
+(async function () {
+  "use strict";
   await main();
 })();


### PR DESCRIPTION
# Re allow click on collection

## Issue
### Description
When adding the search in the sidebar, we were able to filter collections, but not to click on it anymore.
This PR fixes it

![image](https://user-images.githubusercontent.com/3996102/95767121-8d590480-0cb4-11eb-86cb-fb5590555ce0.png)


### Steps to Test or Reproduce
Use the `master` branch, try the addon, try to click on a collection, it's not working
Use this branch, try the addon, try to click on a collection, it's working

## Done
- Use prepend instead of directly setting innerHTML (that was removing de facto all the bindings that were existing, while prepend just adds a new DOM node)
- Refactor
- Bump version to make it autoupdate
